### PR TITLE
fix: Windows / Git Bash install silently breaks ijfw CLI

### DIFF
--- a/mcp-server/src/cross-orchestrator-cli.js
+++ b/mcp-server/src/cross-orchestrator-cli.js
@@ -8,7 +8,7 @@
 // Zero external deps. Parse argv manually.
 
 import { readFileSync, existsSync, writeFileSync, mkdirSync, statSync, openSync, readSync, closeSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { join, dirname, basename, isAbsolute, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -981,11 +981,12 @@ host.appendChild(range.createContextualFragment(marked.parse(md)));
 // Only dispatch when run directly. When imported as a module (e.g. by tests),
 // skip the CLI entry so the test runner can use exported helpers.
 
+// pathToFileURL normalizes both Windows drive paths (C:\...) and MSYS-style
+// paths (/c/...) into the same file:///C:/... form that import.meta.url uses,
+// so this comparison works on Git Bash / MINGW64 as well as POSIX shells.
 const isMainModule = (() => {
   try {
-    return import.meta.url === `file://${process.argv[1]}`
-      || import.meta.url === `file://${fileURLToPath(import.meta.url)}`
-      && process.argv[1] === fileURLToPath(import.meta.url);
+    return import.meta.url === pathToFileURL(process.argv[1]).href;
   } catch {
     return false;
   }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1053,12 +1053,24 @@ else
 
   CLI_LINKED=0
   CLI_FAILED=0
+  CLI_COPIED=0
   for bin in $CLI_BINS; do
     src="$CLI_SRC_DIR/$bin"
     dst="$CLI_LINK_DIR/$bin"
     if [ -f "$src" ]; then
       if ln -sfn "$src" "$dst" 2>/dev/null; then
-        CLI_LINKED=$((CLI_LINKED + 1))
+        # Git Bash / MINGW64 silently falls back to a file copy when the user
+        # lacks Windows symlink privileges (no admin, no Developer Mode, no
+        # MSYS=winsymlinks:nativestrict). The copy sits in ~/.local/bin with no
+        # way to resolve back to the install tree, so the launcher's readlink
+        # walk fails and `ijfw` errors out. Verify with -L and treat a copy as
+        # a failure so the user gets a real fix hint instead of silent breakage.
+        if [ -L "$dst" ]; then
+          CLI_LINKED=$((CLI_LINKED + 1))
+        else
+          CLI_COPIED=$((CLI_COPIED + 1))
+          rm -f "$dst"
+        fi
       else
         CLI_FAILED=$((CLI_FAILED + 1))
       fi
@@ -1079,6 +1091,16 @@ else
   fi
   if [ "$CLI_FAILED" -gt 0 ]; then
     printf '  %s[!]%s %d commands could not be linked (check permissions on %s)\n' "$C_YELLOW" "$C_RESET" "$CLI_FAILED" "$CLI_LINK_DIR"
+  fi
+  if [ "$CLI_COPIED" -gt 0 ]; then
+    printf '  %s[!]%s %d commands could not be symlinked on this Windows shell.\n' "$C_YELLOW" "$C_RESET" "$CLI_COPIED"
+    printf '      Git Bash falls back to copies without symlink privileges, which breaks the launcher.\n'
+    printf '      Fix one of:\n'
+    printf '        %s1.%s Enable Developer Mode (Settings > Privacy & security > For developers), then rerun.\n' "$C_BOLD" "$C_RESET"
+    printf '        %s2.%s Rerun this installer from Git Bash launched as Administrator.\n' "$C_BOLD" "$C_RESET"
+    printf '        %s3.%s In Git Bash: %sexport MSYS=winsymlinks:nativestrict%s, then rerun.\n' "$C_BOLD" "$C_RESET" "$C_BOLD" "$C_RESET"
+    printf '      Or skip ~/.local/bin wiring and add %s%s%s to PATH directly.\n' "$C_BOLD" "$CLI_SRC_DIR" "$C_RESET"
+    CLI_NEEDS_SYMLINK_FIX=1
   fi
 fi
 
@@ -1216,7 +1238,9 @@ if [ "$MCP_OK" -eq 1 ]; then
 else
   printf '  %s║   MCP server: could not verify (check node installation)     ║%s\n' "$C_YELLOW" "$C_RESET"
 fi
-if [ "${CLI_NEEDS_PATH:-0}" -eq 1 ]; then
+if [ "${CLI_NEEDS_SYMLINK_FIX:-0}" -eq 1 ] && [ "${CLI_LINKED:-0}" -eq 0 ]; then
+  printf '  %s║   CLI: symlinks blocked on Windows (see fix above)           ║%s\n' "$C_YELLOW" "$C_RESET"
+elif [ "${CLI_NEEDS_PATH:-0}" -eq 1 ]; then
   printf '  %s║   CLI: add ~/.local/bin to PATH (see above) for `ijfw` cmd   ║%s\n' "$C_YELLOW" "$C_RESET"
 elif [ "${CLI_LINKED:-0}" -gt 0 ]; then
   printf '  %s║   CLI: ijfw command ready (try: ijfw doctor)                 ║%s\n' "$C_GREEN" "$C_RESET"


### PR DESCRIPTION
## Summary

Two Windows-specific install bugs that compound — the installer claims success, then every `ijfw` command exits 0 with no output. Found while installing from a fork on Windows 11 via Git Bash.

**Bug 1 — CLI silent exit on Git Bash ([mcp-server/src/cross-orchestrator-cli.js:984-992](https://github.com/TheRealSeanDonahoe/ijfw/blob/main/mcp-server/src/cross-orchestrator-cli.js#L984-L992))**

The `isMainModule` check compares `import.meta.url` against `` `file://${process.argv[1]}` ``. On MINGW64 / Git Bash, `process.argv[1]` arrives as `/c/Users/.../cli.js` while `import.meta.url` is `file:///C:/Users/.../cli.js`. Neither branch of the `||` matches, `isMainModule` is `false`, the dispatch block is skipped, Node exits 0 with no output — for every subcommand, not just `doctor`.

Fix: use `pathToFileURL(process.argv[1]).href` which normalizes both path flavors to the same `file:///C:/...` form `import.meta.url` uses. No behavior change on Linux/macOS.

**Bug 2 — installer claims success when Windows blocks symlinks ([scripts/install.sh:1056-1066](https://github.com/TheRealSeanDonahoe/ijfw/blob/main/scripts/install.sh#L1056-L1066))**

`ln -s` on MINGW64 silently degrades to a file **copy** when the user lacks Windows symlink privileges (no admin, no Developer Mode, no `MSYS=winsymlinks:nativestrict`). `ln`'s exit code is 0 in both cases, so the installer prints `[+] 5 commands linked` and the banner says `CLI: ijfw command ready`. But the copy sits in `~/.local/bin` as a standalone file — the launcher's `readlink` walk can never trace back to the install tree, and every `ijfw` invocation errors with `launcher expects CLI at ~/.local/bin/../src/cross-orchestrator-cli.js`.

Fix: `[ -L "$dst" ]` check after `ln -s` separates real symlinks (`CLI_LINKED`) from copy-fallbacks (`CLI_COPIED`, which are removed). When a copy-fallback is detected, print a yellow hint listing the three real fixes (Developer Mode, admin shell, `winsymlinks=nativestrict`) plus a PATH-edit fallback. Final banner surfaces the same state. Zero behavior change on Linux/macOS where `ln -s` always produces real symlinks.

## Repro (before this PR)

On Windows 11 / Git Bash, without admin or Developer Mode:

```bash
git clone https://github.com/TheRealSeanDonahoe/ijfw.git ~/.ijfw
cd ~/.ijfw && bash scripts/install.sh
# Installer banner: "IJFW is ready. CLI: ijfw command ready"
ijfw doctor
# "IJFW launcher expects CLI at /c/Users/<you>/.local/bin/../src/cross-orchestrator-cli.js -- re-run the installer"
```

Even after symlinking `~/.local/bin/ijfw` manually so the launcher finds `cross-orchestrator-cli.js`:

```bash
ijfw doctor     # node exec succeeds, exits 0, zero stdout
ijfw --help     # same
ijfw status     # same
```

Tracing with `bash -x "$(command -v ijfw)" doctor` shows the `node` exec fires cleanly — the silent exit is inside the CLI itself, from the broken `isMainModule` check.

## After this PR

```
ijfw doctor -- roster + key probe

  [ ok ] copilot CLI -- Copilot CLI ready
  [ ok ] claude CLI -- Claude Code ready
  [ .. ] codex CLI -- standing by
         fix: npm install -g @openai/codex
  ...

At least one auditor is reachable. Run `ijfw cross audit <file>` to start.

Integration depth:
  Claude Code: native plugin + MCP
  Codex: native skills + hooks + context file + MCP
  Gemini: native extension + skills + hooks + commands + policy + MCP
  Cursor: rules + MCP
  Windsurf: rules + MCP
  Copilot: instructions + MCP
```

## Test plan

- [x] `bash -n scripts/install.sh` — syntax clean
- [x] `node --check mcp-server/src/cross-orchestrator-cli.js` — syntax clean
- [x] Manual repro on Windows 11 + Git Bash (MINGW64), no admin, no Developer Mode
- [x] `ijfw doctor`, `ijfw --help`, `ijfw status` all produce expected output after the CLI fix
- [ ] Verify no regression on macOS — `ln -s` always real there, `[ -L ]` passes, `CLI_COPIED` stays 0
- [ ] Verify no regression on Linux CI — same reasoning
- [ ] Fresh install on Windows with Developer Mode **off** produces the new yellow hint block (no false-positive success banner)
- [ ] Fresh install on Windows with Developer Mode **on** (or admin shell) produces the existing green `[+] 5 commands linked` path unchanged

The last three bullets I can't validate from a single machine — leaving them for CI / other reviewers.

## Notes for the maintainer

Fork install flow used for the repro:

```bash
git clone https://github.com/TrueNorthTeamsAI/ijfw.git C:\Source\...\ijfw
# Created a Windows directory junction so ~/.ijfw points at the dev clone:
cmd //c mklink /J "$USERPROFILE\.ijfw" "C:\Source\...\ijfw"
bash scripts/install.sh
```

Happy to split this into two PRs if you'd prefer — the commits are already separate and either fix stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)