### PR TITLE
feat(roster): add qwen-code (Qwen 3 Coder) to cross-audit roster

### DIFF
--- a/mcp-server/src/audit-roster.js
+++ b/mcp-server/src/audit-roster.js
@@ -35,6 +35,16 @@ export const ROSTER = [
     apiFallback: { provider: 'google', model: 'gemini-2.0-flash', authEnv: 'GEMINI_API_KEY', endpoint: 'https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent' },
   },
   {
+    id: 'qwen',
+    family: 'oss',
+    model: '',
+    name: 'Qwen Code',
+    invoke: 'qwen -p',
+    note: 'Apache-2.0 weights (Qwen3-Coder-480B-A35B), agentic-tuned (~67% SWE-Bench Verified). Fork of gemini-cli; supports qwen-oauth (free Coding Plan tier), plus openai/anthropic/gemini auth-types via `qwen auth`. Diversity value for Trident: third independent training lineage outside openai/google.',
+    detect: (env) => Boolean(env.QWEN_SESSION) || /(?:^|\W)qwen(?:\W|$)/i.test(env._ || ''),
+    apiFallback: { provider: 'openai-compat', model: 'qwen3-coder-plus', authEnv: 'DASHSCOPE_API_KEY', endpoint: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions' },
+  },
+  {
     id: 'opencode',
     family: 'oss',
     model: '',

--- a/mcp-server/test-audit-roster.js
+++ b/mcp-server/test-audit-roster.js
@@ -4,9 +4,13 @@ import { ROSTER, detectSelf, rosterFor, defaultAuditor, formatRoster, pickAudito
 
 test('ROSTER has expected ids', () => {
   const ids = ROSTER.map(e => e.id);
-  for (const expected of ['codex', 'gemini', 'opencode', 'aider', 'copilot', 'claude']) {
+  for (const expected of ['codex', 'gemini', 'qwen', 'opencode', 'aider', 'copilot', 'claude']) {
     assert.ok(ids.includes(expected), `missing: ${expected}`);
   }
+});
+
+test('detectSelf returns qwen on QWEN_SESSION', () => {
+  assert.equal(detectSelf({ QWEN_SESSION: 'abc' }), 'qwen');
 });
 
 test('detectSelf returns claude when Claude Code env is set', () => {


### PR DESCRIPTION
## Summary

Adds **qwen-code** (Qwen 3 Coder, Alibaba, Apache-2.0) as a third foundation-model lineage in the cross-audit roster, alongside codex (openai) and gemini (google).

The CLI is a fork of gemini-cli (`npm install -g @qwen-code/qwen-code`), so the invocation pattern (`qwen -p`) is already compatible with the existing dispatcher contract. ~67% SWE-Bench Verified per Qwen3-Coder-480B-A35B's published numbers, comparable to Kimi K2 with a smaller activated model and a maintained CLI.

## Why a third lineage

`pickAuditors` diversity strategy currently has `TARGET_FAMILIES = ['openai', 'google']`. Adding qwen as `family: 'oss'` doesn't disrupt that targeting but adds:
- A real third lineage when the caller is itself in openai or google family (today, the backfill drops to opencode/aider which often aren't installed)
- An Apache-licensed option when license-sensitivity matters
- A locally-runnable backbone (Ollama supports qwen3-coder variants) for zero-API-cost auditing

## What's in this PR

- New ROSTER entry between gemini and opencode (priority placement: maintained CLI + working API fallback)
- `detectSelf` rule: `QWEN_SESSION` env var + conservative `env._` regex
- `apiFallback` to DashScope's OpenAI-compat endpoint (`dashscope-intl.aliyuncs.com`) with `DASHSCOPE_API_KEY`
- Test extended to assert `qwen` is in roster + new `detectSelf` test for `QWEN_SESSION`

## What's NOT in this PR (pre-existing, observed during diff review)

These are bugs in the surrounding code that I noticed but kept out of scope for a clean reviewable diff. Each is suitable for a separate PR:

1. `detectSelf` for `codex` uses `CODEX_HOME` -- a config-path env var that's set whenever codex is *installed*, not when it's the *active session*. This causes false self-exclusion. **I avoided this exact trap for qwen by deliberately NOT using `QWEN_HOME`** -- worth applying the same fix to codex.
2. `formatRoster` prints API-only-reachable auditors as `install` even when their auth env key is set. `isReachable` returns `api: true` for them but the format function only consults `installed`.
3. `defaultAuditor` returns first non-self entry without checking `isReachable`, so it can return an unreachable pick.
4. `pickAuditors({ only })` mode does not exclude self -- you can request self-audit explicitly.
5. `_installedCache` is mutable module state without a test-scoped reset hook -- assertions that throw mid-test can leak cache state into later tests.
6. Tests that probe host PATH (`isInstalled`) make results non-deterministic across dev/CI.

Happy to file follow-up PRs for any of these if useful.

## Test plan
- [x] `node --test mcp-server/test-audit-roster.js` -- all 44 tests pass locally on macOS, Node v25
- [x] Fresh install of qwen-code CLI (`npm i -g @qwen-code/qwen-code` -> `qwen` 0.15.4) -- detected by `isInstalled('qwen')` after auth via `qwen auth`
- [ ] Reviewer to confirm dispatcher handles `provider: 'openai-compat'` gracefully (graceful CLI-required fallback if not yet supported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
