### PR TITLE
release: v1.6.4 -- reject bundle-internal project roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,39 @@
 # Changelog
 
-## [1.6.3] - 2026-06-13 - Smart-detect seed gate (stop littering scratch dirs)
+## [1.6.4] - 2026-07-10 - Reject bundle-internal project roots (never write inside a signed app)
+
+IJFW could adopt a *writable* directory as its project root even when that
+directory lived inside another app's signed bundle. When Wayland spawned the
+IJFW MCP server with its working directory inside `Wayland.app` (an
+`app.asar.unpacked` path), `safeProjectDir()` accepted it and the layout
+migration wrote `.ijfw/.layout-version` inside the bundle — breaking the
+code-signature seal, which on hardened-runtime macOS makes the OS deny every
+child process the host app tries to spawn (FerroxLabs/wayland#755). This
+release refuses any bundle-internal root, everywhere a root can enter.
+
+### Fixed
+
+- **`safeProjectDir()` rejects bundle-internal candidates.** A new
+  `isBundleInternalPath` guard refuses any path containing an `*.asar` /
+  `*.asar.unpacked` segment or an `*.app` bundle interior (fs-backed check for
+  a sibling `Contents`), case-insensitive, both separator styles. The check
+  runs before the writability probe, and a rejected candidate falls through to
+  the next signal (`IJFW_PROJECT_DIR` → `CLAUDE_PROJECT_DIR` → cwd) and finally
+  to `homedir()` — never a crash.
+- **All entry points share one vetted resolver.** The guard was extracted to
+  `mcp-server/src/lib/project-root-guard.js` and applied at every site that
+  previously fell back to a raw `IJFW_PROJECT_DIR || process.cwd()`: the
+  colon-syntax dispatch layer (which feeds `fts5.openDb()` and would otherwise
+  `mkdir` `.ijfw/index` under an unvetted root), the memory/compute FTS5
+  openers, `cli-run`, the state-SDK path, and the `ijfw_run` / `ijfw_search`
+  caller-supplied roots.
+- **Symlinked roots can't smuggle a bundle path in.** Env- and caller-supplied
+  candidates are `realpath`-resolved before the bundle check.
+
+### Notes
+
+- Installed copies pick this up on the next `ijfw update` (or a fresh
+  `npx @ijfw/install`).
 
 IJFW used to write its project files into every directory a session started in,
 including throwaway scratch dirs and ephemeral "temporary spaces" (e.g. Wayland).

--- a/claude/.claude-plugin/plugin.json
+++ b/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ijfw",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "AI efficiency framework. Smarter output, intelligent routing, persistent memory, context discipline, project workflows. One install. Zero config. It just fucking works.",
   "author": {
     "name": "Sean Donahoe",

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ijfw",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "IJFW -- AI efficiency layer for Codex. 19 workflow skills, 22 command aliases, 6 hook events, persistent project memory via MCP, project teams, swarm orchestration, and design intelligence. One install layer across 15 AI coding platforms.",
   "author": "Sean Donahoe",
   "contributors": [

--- a/installer/package-lock.json
+++ b/installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ijfw/install",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ijfw/install",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "MIT",
       "bin": {
         "ijfw": "dist/ijfw.js",

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ijfw/install",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "One-command installer for IJFW -- the AI efficiency layer. One install, every AI coding agent, zero config.",
   "type": "module",
   "bin": {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ijfw/memory-server",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ijfw/memory-server",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^11.5.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ijfw/memory-server",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Cross-platform persistent memory server for IJFW. 14 MCP tools (memory + admin/update + brain). Works with 15 platforms: 14 via MCP (Claude Code, Codex, Gemini CLI, Cursor, Windsurf, Copilot, Hermes, Wayland, OpenCode, QwenCode, Cline, KimiCode, OpenClaw, Antigravity) plus Aider via the rules-only tier.",
   "author": "Sean Donahoe",
   "contributors": [


### PR DESCRIPTION
Version bump + CHANGELOG for **v1.6.4**, shipping the #21 hardening (reject bundle-internal project roots across all entry points; closes the FerroxLabs/wayland#755 write vector).

Bumped to 1.6.4: mcp-server, installer (+ lockfiles), claude & codex plugin manifests.

Merge → tag `v1.6.4` → `publish.yml` publishes `@ijfw/install` + `@ijfw/memory-server` to npm. Installed copies pick it up on `ijfw update`.