### PR TITLE
fix(blackboard): read cache served stale task state on mtime-quantum collision

### DIFF
--- a/mcp-server/src/blackboard.js
+++ b/mcp-server/src/blackboard.js
@@ -90,7 +90,10 @@ function writeJson(path, data) {
       `tasks/claims (e.g. archive completed tasks) before retrying.`,
     );
   }
-  return writeAtomic(path, serialized, { mode: 0o600 });
+  const res = writeAtomic(path, serialized, { mode: 0o600 });
+  // Same-process readers must never see pre-write state (v1.6.4-gate flake).
+  invalidateBlackboardReadCache(path);
+  return res;
 }
 
 function readJsonl(path, limit = 5) {
@@ -154,27 +157,50 @@ export function initBlackboard(projectRoot = process.cwd()) {
 const BLACKBOARD_READ_CACHE = new Map();
 const BLACKBOARD_READ_CACHE_MAX = 32;
 
-function blackboardFileMtime(path) {
+// v1.6.4-gate flake root cause: the cache was keyed on mtimeMs ALONE and
+// writers never invalidated it. Two writes landing in the same filesystem
+// timestamp quantum (Linux coarse clock: 1-4ms — realistic under parallel-
+// suite load; also any same-quantum cross-process write) made the next read
+// return the PREVIOUS parsed state: blockSwarmTask's update was invisible to
+// readySwarmTask, which then failed 'task-not-blocked' on a stale 'ready'.
+// Deterministic repro: pin tasks.json mtime with utimesSync around an update.
+//
+// Fix: the validity stamp is (mtimeMs, size, ino). writeAtomic renames a
+// fresh temp file over the target, so the inode changes on every write via
+// writeAtomic — same-quantum rewrites and foreign-process writers both miss
+// the cache. (A cross-process writer could in theory recycle a just-freed
+// ino AND match size AND land in the same mtime quantum — negligible, and
+// strictly narrower than the bug being fixed.) writeJson additionally drops
+// entries for the path it wrote, which closes the same-process case
+// UNCONDITIONALLY, independent of any inode/stat semantics.
+function blackboardFileStamp(path) {
   try {
-    return statSync(path).mtimeMs;
+    const st = statSync(path);
+    return `${st.mtimeMs}:${st.size}:${st.ino}`;
   } catch {
-    return 0;
+    return null; // forces a cache miss; transient stat failure degrades safely
   }
 }
 
-function getCachedJson(cacheKey, path, mtime, fallback, validator) {
+function getCachedJson(cacheKey, path, stamp, fallback, validator) {
   const cached = BLACKBOARD_READ_CACHE.get(cacheKey);
-  if (cached && cached.path === path && cached.mtime === mtime && mtime > 0) {
+  if (cached && cached.path === path && cached.stamp === stamp && stamp !== null) {
     return cached.value;
   }
   const value = readJson(path, fallback, validator);
-  BLACKBOARD_READ_CACHE.set(cacheKey, { path, mtime, value });
+  BLACKBOARD_READ_CACHE.set(cacheKey, { path, stamp, value });
   // Lightweight LRU eviction: drop oldest entry when over cap.
   if (BLACKBOARD_READ_CACHE.size > BLACKBOARD_READ_CACHE_MAX) {
     const firstKey = BLACKBOARD_READ_CACHE.keys().next().value;
     if (firstKey !== undefined) BLACKBOARD_READ_CACHE.delete(firstKey);
   }
   return value;
+}
+
+function invalidateBlackboardReadCache(path) {
+  for (const [key, entry] of BLACKBOARD_READ_CACHE) {
+    if (entry.path === path) BLACKBOARD_READ_CACHE.delete(key);
+  }
 }
 
 // Exposed for tests + cache invalidation hooks. Clears all memoised entries.
@@ -184,13 +210,13 @@ export function _resetBlackboardReadCache() {
 
 export function readBlackboard(projectRoot = process.cwd()) {
   const paths = blackboardPaths(projectRoot);
-  // F-SPD-2: mtime-keyed memo. When tasks.json + claims.json are unchanged
-  // we skip JSON.parse entirely. mtime===0 forces a miss so transient stat
-  // failures degrade to the un-cached path safely.
-  const tasksMtime = blackboardFileMtime(paths.tasks);
-  const claimsMtime = blackboardFileMtime(paths.claims);
-  const tasks = getCachedJson(`${paths.root}::tasks`, paths.tasks, tasksMtime, defaultTasks, validTasks);
-  const claims = getCachedJson(`${paths.root}::claims`, paths.claims, claimsMtime, defaultClaims, validClaims);
+  // F-SPD-2: stamp-keyed memo. When tasks.json + claims.json are unchanged
+  // (mtime+size+ino identical) we skip JSON.parse entirely. stamp===null
+  // forces a miss so transient stat failures degrade to the un-cached path.
+  const tasksStamp = blackboardFileStamp(paths.tasks);
+  const claimsStamp = blackboardFileStamp(paths.claims);
+  const tasks = getCachedJson(`${paths.root}::tasks`, paths.tasks, tasksStamp, defaultTasks, validTasks);
+  const claims = getCachedJson(`${paths.root}::claims`, paths.claims, claimsStamp, defaultClaims, validClaims);
   return {
     paths,
     tasks,

--- a/mcp-server/test-swarm-planner.js
+++ b/mcp-server/test-swarm-planner.js
@@ -1,9 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { claimArtifact, initBlackboard } from './src/blackboard.js';
+import { blackboardPaths, claimArtifact, initBlackboard } from './src/blackboard.js';
 import { createTeamAssembly } from './src/team/generator.js';
 import {
   blockSwarmTask,
@@ -22,6 +22,34 @@ function makeTmp() {
 
 function cleanup(dir) {
   rmSync(dir, { recursive: true, force: true });
+}
+
+// Release-gate flake, root-caused (v1.6.4 gate: `blockSwarmTask records
+// blocker and readySwarmTask clears it` failed once under the full parallel
+// suite, green in isolation): blackboard.js's BLACKBOARD_READ_CACHE was
+// keyed on mtimeMs alone and never invalidated by writers, so two tasks.json
+// writes inside one filesystem timestamp quantum made the next read return
+// the PREVIOUS parsed state — readySwarmTask saw a stale 'ready' and failed
+// 'task-not-blocked'. Fixed in blackboard.js (stamp = mtime+size+ino, plus
+// writeJson invalidation); the deterministic regression pin lives below
+// ('read cache must not serve stale task state...').
+//
+// mustPrepare() + result-payload assertion messages are hardening from the
+// same investigation: lifecycle tests called prepareSwarmTasks() without
+// asserting it succeeded, so any transient setup failure would surface as a
+// misleading downstream assertion with the real error swallowed.
+function mustPrepare(dir, options) {
+  const prepared = prepareSwarmTasks(dir, options);
+  assert.equal(prepared.ok, true,
+    `prepareSwarmTasks must succeed (got: ${JSON.stringify({ ok: prepared.ok, error: prepared.error, written: prepared.written })})`);
+  return prepared;
+}
+
+// Compact result echo for assertion messages — status/error, never the
+// full task graph (keeps TAP output readable when it does fire).
+function why(result) {
+  if (!result || typeof result !== 'object') return String(result);
+  return JSON.stringify({ ok: result.ok, error: result.error, status: result.task && result.task.status });
 }
 
 test('buildSwarmPlan asks for team assembly when missing', () => {
@@ -176,11 +204,11 @@ test('swarm task lifecycle starts, completes, and releases claims', () => {
   try {
     createTeamAssembly(dir, { archetype: 'software' });
     initBlackboard(dir);
-    prepareSwarmTasks(dir);
+    mustPrepare(dir);
 
     const taskId = 'swarm:w1:runtime-module';
     const started = startSwarmTask(dir, taskId);
-    assert.equal(started.ok, true);
+    assert.equal(started.ok, true, `start must succeed (got: ${why(started)})`);
     assert.equal(started.task.status, 'in_progress');
     assert.equal(started.claims[0].artifact_id, 'runtime-module');
 
@@ -188,7 +216,7 @@ test('swarm task lifecycle starts, completes, and releases claims', () => {
       message: 'tests passed',
       evidence: { commitSha: 'deadbeefcafe1234' },
     });
-    assert.equal(completed.ok, true);
+    assert.equal(completed.ok, true, `complete must succeed (got: ${why(completed)})`);
     assert.equal(completed.task.status, 'done');
     assert.equal(completed.releases[0].released, 1);
 
@@ -204,20 +232,20 @@ test('startSwarmTask requires dependencies to be done', () => {
   try {
     createTeamAssembly(dir, { archetype: 'content' });
     initBlackboard(dir);
-    prepareSwarmTasks(dir);
+    mustPrepare(dir);
 
     const blocked = startSwarmTask(dir, 'swarm:w2:article-draft');
-    assert.equal(blocked.ok, false);
+    assert.equal(blocked.ok, false, `dependent task must not start (got: ${why(blocked)})`);
     assert.equal(blocked.error, 'dependency-not-done');
 
-    assert.equal(startSwarmTask(dir, 'swarm:w1:campaign-brief').ok, true);
-    assert.equal(
-      completeSwarmTask(dir, 'swarm:w1:campaign-brief', {
-        evidence: { commitSha: 'beadcafe7654321' },
-      }).ok,
-      true,
-    );
-    assert.equal(startSwarmTask(dir, 'swarm:w2:article-draft').ok, true);
+    const startBrief = startSwarmTask(dir, 'swarm:w1:campaign-brief');
+    assert.equal(startBrief.ok, true, `brief must start (got: ${why(startBrief)})`);
+    const completeBrief = completeSwarmTask(dir, 'swarm:w1:campaign-brief', {
+      evidence: { commitSha: 'beadcafe7654321' },
+    });
+    assert.equal(completeBrief.ok, true, `brief must complete (got: ${why(completeBrief)})`);
+    const startDraft = startSwarmTask(dir, 'swarm:w2:article-draft');
+    assert.equal(startDraft.ok, true, `draft must start once dependency is done (got: ${why(startDraft)})`);
   } finally {
     cleanup(dir);
   }
@@ -228,17 +256,48 @@ test('blockSwarmTask records blocker and readySwarmTask clears it', () => {
   try {
     createTeamAssembly(dir, { archetype: 'design' });
     initBlackboard(dir);
-    prepareSwarmTasks(dir);
+    mustPrepare(dir);
 
     const blocked = blockSwarmTask(dir, 'swarm:w1:screen-system', { message: 'needs design source' });
-    assert.equal(blocked.ok, true);
+    assert.equal(blocked.ok, true, `block must succeed (got: ${why(blocked)})`);
     assert.equal(blocked.task.status, 'blocked');
     assert.equal(blocked.task.blocker, 'needs design source');
 
     const ready = readySwarmTask(dir, 'swarm:w1:screen-system');
-    assert.equal(ready.ok, true);
+    assert.equal(ready.ok, true, `ready must succeed (got: ${why(ready)})`);
     assert.equal(ready.task.status, 'ready');
     assert.equal(ready.task.blocker, null);
+  } finally {
+    cleanup(dir);
+  }
+});
+
+// Regression pin for the v1.6.4 release-gate flake root cause. Pinning
+// tasks.json's mtime to the same whole-second value before AND after
+// blockSwarmTask's write simulates two writes landing in one filesystem
+// timestamp quantum (Linux coarse clock under parallel-suite load). With the
+// old mtime-only cache key this deterministically made readySwarmTask read
+// the stale pre-block state and fail 'task-not-blocked'. The stamp now
+// includes size+ino (writeAtomic renames a fresh inode on every write) and
+// writeJson invalidates, so the pinned mtime must NOT fool the cache.
+test('read cache must not serve stale task state when writes share an mtime quantum', () => {
+  const dir = makeTmp();
+  try {
+    createTeamAssembly(dir, { archetype: 'design' });
+    initBlackboard(dir);
+    mustPrepare(dir);
+    const paths = blackboardPaths(dir);
+    const T = 1700000000; // whole seconds — identical mtime across the update
+
+    utimesSync(paths.tasks, T, T);
+    const blocked = blockSwarmTask(dir, 'swarm:w1:screen-system', { message: 'needs design source' });
+    assert.equal(blocked.ok, true, `block must succeed (got: ${why(blocked)})`);
+    utimesSync(paths.tasks, T, T); // same quantum after the update write
+
+    const ready = readySwarmTask(dir, 'swarm:w1:screen-system');
+    assert.equal(ready.ok, true,
+      `readySwarmTask must see the block despite identical mtimes (got: ${why(ready)}) — stale read cache regression`);
+    assert.equal(ready.task.status, 'ready');
   } finally {
     cleanup(dir);
   }


### PR DESCRIPTION
Root cause of the v1.6.4 release-gate flake ('blockSwarmTask records
blocker and readySwarmTask clears it', green in isolation): the
BLACKBOARD_READ_CACHE was keyed on mtimeMs ALONE and writers never
invalidated it. Two tasks.json writes inside one filesystem timestamp
quantum (Linux coarse clock is 1-4ms - realistic under parallel-suite
CPU load, and CI runs ubuntu) made the next read return the PREVIOUS
parsed state: blockSwarmTask's update was invisible to readySwarmTask,
which failed 'task-not-blocked' on a stale 'ready'. Reproduced
deterministically by pinning tasks.json's mtime with utimesSync around
the update; also a production staleness hazard for any long-running MCP
server doing rapid successive task updates.

Credit: surfaced by the adversarial review of the first (diagnostics-
only) version of this change, which correctly rejected 'no reproducible
shared state' and produced the repro.

Fix:
- cache validity stamp is now (mtimeMs, size, ino) - writeAtomic renames
  a fresh temp file over the target so the inode changes on EVERY write;
  same-quantum rewrites and foreign-process writers both miss the cache.
- writeJson drops cache entries for the path it wrote (immediate
  same-process invalidation, independent of stat resolution).

Tests:
- deterministic regression pin (utimesSync mtime-quantum simulation);
  mutation-checked: fails against the old cache code, passes with the fix.
- lifecycle-test hardening from the same investigation: mustPrepare()
  asserts setup success, and start/complete/block/ready assertions carry
  the actual result payload so any future occurrence self-diagnoses.

Suite: 3603 pass / 0 fail / 35 skip (Node 22). Preflight 11/11 PASS.
