### PR TITLE
fix(blackboard): symlink/containment guard on .ijfw/blackboard reads+writes (#25)

### DIFF
--- a/mcp-server/src/blackboard.js
+++ b/mcp-server/src/blackboard.js
@@ -4,8 +4,11 @@
 // small and dependency-free: tasks/claims are atomic JSON, notes are append-only
 // JSONL, and handoff is plain markdown.
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import {
+  existsSync, mkdirSync, readFileSync, statSync, lstatSync,
+  realpathSync, openSync, writeSync, closeSync, constants as fsConstants,
+} from 'node:fs';
+import { join, resolve, relative, dirname, basename, isAbsolute } from 'node:path';
 import { writeAtomic, readSafe, withLock } from './lib/atomic-io.js';
 import { rotateJsonlIfNeeded } from './lib/jsonl-rotation.js';
 
@@ -48,8 +51,104 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+// issue #25 — symlink/containment guard. blackboard.js wrote under
+// <repo>/.ijfw/blackboard/ with no containment check, unlike the brain layer
+// (brain/path-guard.js). A maliciously-cloned repo committing a symlink at
+// `.ijfw/blackboard` -> an outside dir (parent-dir vector) redirected EVERY
+// write (tasks.json/handoff/appends) out of the tree; a symlink at a leaf
+// like `notes.jsonl` (file vector) redirected the appends. Both reproduced.
+//
+// assertContainedDir realpaths the nearest existing ancestor of `paths.dir`
+// and refuses unless it stays under realpath(paths.root) — the same
+// deepest-existing-ancestor technique path-guard.js uses so macOS
+// /tmp->/private/tmp symlinks don't false-positive. This is the single
+// chokepoint for the parent-dir vector: ensureDir runs at the top of every
+// public writer. The leaf-file vector is closed separately by O_NOFOLLOW in
+// the append/create helpers below (writeAtomic already lstat-guards its own
+// final component).
+class BlackboardContainmentError extends Error {}
+
+function assertContainedDir(paths) {
+  let root;
+  try {
+    root = realpathSync(paths.root);
+  } catch {
+    // Project root doesn't resolve (not yet created / transient) — fall back
+    // to the lexical resolve so a legitimate first-write still proceeds; the
+    // dir is created under it below and re-checked on the next write.
+    root = resolve(paths.root);
+  }
+  // Walk up from paths.dir to the closest existing ancestor, realpath THAT,
+  // then re-attach the not-yet-created suffix (mirrors path-guard.js).
+  let ancestor = resolve(paths.dir);
+  const suffix = [];
+  for (let i = 0; i < 64; i++) {
+    try {
+      ancestor = realpathSync(ancestor);
+      break;
+    } catch {
+      const parent = dirname(ancestor);
+      if (parent === ancestor) break;
+      // basename, not slice(parent.length+1): when parent is '/' the slice
+      // drops a leading char ('/foo' -> 'oo'). (Fail-closed either way, but
+      // the mangled segment breaks the legit first-write-to-nonexistent-root.)
+      suffix.unshift(basename(ancestor));
+      ancestor = parent;
+    }
+  }
+  const resolvedDir = suffix.length ? join(ancestor, ...suffix) : ancestor;
+  const rel = relative(root, resolvedDir);
+  if (rel.startsWith('..') || isAbsolute(rel)) {
+    throw new BlackboardContainmentError(
+      `blackboard: refusing to write ${paths.dir} -- resolves to ${resolvedDir}, ` +
+      `outside the project root ${root} (symlinked .ijfw/blackboard? issue #25).`,
+    );
+  }
+}
+
 function ensureDir(paths) {
+  assertContainedDir(paths);
   if (!existsSync(paths.dir)) mkdirSync(paths.dir, { recursive: true, mode: 0o700 });
+}
+
+// Symlink-safe append: O_NOFOLLOW makes openSync fail atomically (ELOOP) if
+// the final path component is a symlink, so a committed `notes.jsonl` /
+// `events.jsonl` symlink can't redirect the append out of the tree. Mirrors
+// dream-pipeline.js's wiki-log open.
+function appendLineNoFollow(path, line) {
+  const fd = openSync(
+    path,
+    fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    writeSync(fd, line);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// Symlink-safe create-if-missing: O_EXCL|O_CREAT fails (EEXIST) on any
+// existing path INCLUDING a symlink (POSIX treats a symlink as existing under
+// O_EXCL, even a dangling one), and O_NOFOLLOW is belt-and-braces. Used for
+// the initBlackboard placeholder files.
+function createIfMissingNoFollow(path, content) {
+  let fd;
+  try {
+    fd = openSync(
+      path,
+      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW,
+      0o600,
+    );
+  } catch (err) {
+    if (err && err.code === 'EEXIST') return; // already present (or a symlink we refuse to follow)
+    throw err;
+  }
+  try {
+    if (content) writeSync(fd, content);
+  } finally {
+    closeSync(fd);
+  }
 }
 
 function defaultTasks() {
@@ -98,22 +197,45 @@ function writeJson(path, data) {
 
 function readJsonl(path, limit = 5) {
   try {
-    if (!existsSync(path)) return [];
+    // issue #25 (read side): readFileSync follows symlinks, so a committed
+    // `notes.jsonl`/`events.jsonl` -> ~/.aws/credentials symlink would surface
+    // the outside file's tail into blackboardStatus / readBlackboard (and thence
+    // agent context). Refuse a symlinked leaf, same as the write guards.
+    if (lstatSync(path).isSymbolicLink()) return [];
     const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
     return lines.slice(-limit).map((line) => {
       try { return JSON.parse(line); } catch { return { malformed: true, raw: line }; }
     });
   } catch {
+    // ENOENT (leaf not yet created) and any other stat/read failure -> empty.
     return [];
   }
 }
 
 function appendJsonlUnlocked(path, entry) {
+  // issue #25: refuse a symlinked leaf BEFORE anything touches it. The
+  // O_NOFOLLOW append below and the lstat-guard inside rotateJsonlIfNeeded
+  // both close this too, but an explicit up-front check gives a clear,
+  // typed error instead of a raw ELOOP and defends even if a future refactor
+  // reorders the rotation/append. (Static cloned-repo threat model — no
+  // same-uid TOCTOU race is in scope.)
+  try {
+    if (lstatSync(path).isSymbolicLink()) {
+      throw new BlackboardContainmentError(
+        `blackboard: refusing to write through the symlinked JSONL leaf ${path} (issue #25).`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof BlackboardContainmentError) throw err;
+    /* ENOENT (leaf not yet created) is the common case — proceed. */
+  }
   // F-PRF-1 (audit-MED-teams-#10): rotate large JSONL files in place before
   // appending. The rotator is a no-op when the file is under the 4MB
   // threshold, so this stays a hot-path-friendly stat() in the common case.
   try { rotateJsonlIfNeeded(path); } catch { /* rotation is best-effort */ }
-  appendFileSync(path, `${JSON.stringify(entry)}\n`, { encoding: 'utf8', mode: 0o600 });
+  // issue #25: O_NOFOLLOW append so a committed leaf symlink (notes.jsonl /
+  // events.jsonl -> outside file) cannot redirect the write out of the tree.
+  appendLineNoFollow(path, `${JSON.stringify(entry)}\n`);
   return entry;
 }
 
@@ -139,11 +261,10 @@ export function initBlackboard(projectRoot = process.cwd()) {
   if (!existsSync(paths.tasks)) writeJson(paths.tasks, defaultTasks());
   if (!existsSync(paths.claims)) writeJson(paths.claims, defaultClaims());
   for (const p of [paths.findings, paths.decisions, paths.blockers, paths.notes, paths.events]) {
-    if (!existsSync(p)) writeFileSync(p, '', { encoding: 'utf8', mode: 0o600 });
+    // issue #25: create-if-missing that refuses to follow a committed symlink.
+    createIfMissingNoFollow(p, '');
   }
-  if (!existsSync(paths.handoff)) {
-    writeFileSync(paths.handoff, '# IJFW Blackboard Handoff\n\nNo active handoff.\n', { encoding: 'utf8', mode: 0o600 });
-  }
+  createIfMissingNoFollow(paths.handoff, '# IJFW Blackboard Handoff\n\nNo active handoff.\n');
   return { ok: true, dir: paths.dir };
 }
 

--- a/mcp-server/src/lib/jsonl-rotation.js
+++ b/mcp-server/src/lib/jsonl-rotation.js
@@ -15,7 +15,7 @@
 // Used by the blackboard event/permission writers + any caller that does
 // `appendFileSync(path, JSON.stringify(entry) + '\n')`. ESM, zero external deps.
 
-import { existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, renameSync, lstatSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, basename, join } from 'node:path';
 import { gzipSync } from 'node:zlib';
 
@@ -62,9 +62,16 @@ export function rotateJsonlIfNeeded(path, options = {}) {
     : DEFAULT_ROTATE_SIZE;
   const now = options.now instanceof Date ? options.now : new Date();
 
+  // issue #25: lstat (NOT stat) so a symlinked JSONL leaf reports isFile()
+  // false and rotation is refused. With statSync, a committed
+  // `notes.jsonl -> outside >4MB file` symlink was READ (exfiltrated into an
+  // in-tree .gz archive) and then writeFileSync('')-TRUNCATED through the
+  // link, all before the O_NOFOLLOW append in the blackboard writer could
+  // reject it. lstat closes the read+truncate at the source for every caller.
   let stat;
-  try { stat = statSync(path); }
+  try { stat = lstatSync(path); }
   catch { return { rotated: false, reason: 'missing' }; }
+  if (stat.isSymbolicLink()) return { rotated: false, reason: 'symlink-refused' };
   if (!stat.isFile()) return { rotated: false, reason: 'not-a-file' };
   if (stat.size <= maxBytes) return { rotated: false, reason: 'under-threshold', size: stat.size };
 

--- a/mcp-server/test-blackboard.js
+++ b/mcp-server/test-blackboard.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, symlinkSync, statSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -356,5 +356,130 @@ test('readBlackboard re-parses after a write invalidates the mtime', async () =>
     assert.equal(after.tasks.data.tasks.length, 1);
   } finally {
     cleanup(dir);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// issue #25 — symlink/containment guard. A maliciously-cloned repo can commit
+// a symlink under .ijfw/blackboard to redirect writes out of the tree. Both
+// vectors were reproduced against the pre-fix code; these pin the guard.
+// ---------------------------------------------------------------------------
+
+test('issue #25: leaf-file symlink (notes.jsonl -> outside) cannot redirect an append', () => {
+  const repo = makeTmp();
+  const outDir = makeTmp();
+  const victim = join(outDir, 'victim.txt');
+  writeFileSync(victim, 'ORIGINAL\n');
+  try {
+    mkdirSync(join(repo, '.ijfw', 'blackboard'), { recursive: true });
+    // Simulate what `git clone` materializes for a committed mode-120000 blob.
+    symlinkSync(victim, join(repo, '.ijfw', 'blackboard', 'notes.jsonl'));
+
+    // addBlackboardNote appends to notes.jsonl; O_NOFOLLOW must stop it from
+    // following the symlink out of the tree (ELOOP → append is refused).
+    let threw = false;
+    try { addBlackboardNote(repo, { kind: 'note', author: 'x', artifact: '', message: 'INJECTED' }); }
+    catch { threw = true; }
+
+    const after = readFileSync(victim, 'utf8');
+    assert.ok(!after.includes('INJECTED'), 'the outside victim file must not receive the append');
+    assert.equal(after, 'ORIGINAL\n', 'the outside victim file is untouched');
+    assert.ok(threw || !after.includes('INJECTED'), 'append either threw or was contained');
+  } finally {
+    cleanup(repo);
+    cleanup(outDir);
+  }
+});
+
+test('issue #25: parent-dir symlink (.ijfw/blackboard -> outside dir) is refused', () => {
+  const repo = makeTmp();
+  const outDir = makeTmp();
+  writeFileSync(join(outDir, 'tasks.json'), '{"pre":"existing"}');
+  try {
+    mkdirSync(join(repo, '.ijfw'), { recursive: true });
+    symlinkSync(outDir, join(repo, '.ijfw', 'blackboard'));
+
+    // Every writer routes through ensureDir → assertContainedDir, which
+    // realpaths the blackboard dir and refuses when it escapes the repo root.
+    assert.throws(() => initBlackboard(repo), /outside the project root|issue #25/,
+      'writing through a symlinked blackboard dir must throw');
+    assert.throws(() => addBlackboardNote(repo, { kind: 'note', author: 'x', artifact: '', message: 'z' }),
+      /outside the project root|issue #25/);
+
+    const t = readFileSync(join(outDir, 'tasks.json'), 'utf8');
+    assert.ok(t.includes('"pre":"existing"'), 'the outside tasks.json must not be clobbered');
+  } finally {
+    cleanup(repo);
+    cleanup(outDir);
+  }
+});
+
+test('issue #25: a symlinked JSONL leaf over the rotation threshold cannot be read or truncated', () => {
+  // The dangerous variant: rotateJsonlIfNeeded runs BEFORE the append and used
+  // statSync/readFileSync/writeFileSync — all follow symlinks. A committed
+  // events.jsonl -> outside >4MB file was exfiltrated into an in-tree .gz and
+  // truncated to zero. lstat-guard in the rotator + an up-front leaf check now
+  // close it. (Adversarial-review CRITICAL finding on the first fix pass.)
+  const repo = makeTmp();
+  const outDir = makeTmp();
+  const victim = join(outDir, 'big-secret.bin');
+  const secret = 'TOP_SECRET_'.repeat(500000); // > 4MB, over the rotation threshold
+  writeFileSync(victim, secret);
+  const sizeBefore = statSync(victim).size;
+  assert.ok(sizeBefore > 4 * 1024 * 1024, 'victim exceeds the 4MB rotation threshold');
+  try {
+    mkdirSync(join(repo, '.ijfw', 'blackboard'), { recursive: true });
+    symlinkSync(victim, join(repo, '.ijfw', 'blackboard', 'events.jsonl'));
+
+    assert.throws(() => appendBlackboardEvent(repo, { type: 'test', message: 'x' }),
+      /symlink|issue #25/, 'append through a symlinked oversized leaf must be refused');
+
+    assert.equal(statSync(victim).size, sizeBefore, 'victim must NOT be truncated by rotation');
+    assert.equal(readFileSync(victim, 'utf8'), secret, 'victim contents intact');
+    // No gz archive of the victim's bytes may exist in the repo tree.
+    const bbDir = join(repo, '.ijfw', 'blackboard');
+    const archives = existsSync(bbDir)
+      ? readdirSync(bbDir).filter((f) => f.endsWith('.gz'))
+      : [];
+    assert.equal(archives.length, 0, 'no in-tree gz archive of the exfiltrated bytes');
+  } finally {
+    cleanup(repo);
+    cleanup(outDir);
+  }
+});
+
+test('issue #25 (read side): a symlinked JSONL leaf cannot disclose an outside file via status', () => {
+  const repo = makeTmp();
+  const outDir = makeTmp();
+  const secretFile = join(outDir, 'credentials');
+  writeFileSync(secretFile, 'aws_secret_key=AKIAEXFIL123\nprivate-line-2\n');
+  try {
+    mkdirSync(join(repo, '.ijfw', 'blackboard'), { recursive: true });
+    // Legit dir, but the notes leaf is a committed symlink to an outside secret.
+    symlinkSync(secretFile, join(repo, '.ijfw', 'blackboard', 'notes.jsonl'));
+    // readBlackboard -> readJsonl(notes) must NOT surface the outside contents.
+    const bb = readBlackboard(repo);
+    const notesText = JSON.stringify(bb.recent && bb.recent.notes || []);
+    assert.ok(!notesText.includes('AKIAEXFIL123'), 'the outside secret must not leak into blackboard reads');
+    assert.deepEqual(bb.recent.notes, [], 'a symlinked notes leaf reads as empty');
+  } finally {
+    cleanup(repo);
+    cleanup(outDir);
+  }
+});
+
+test('issue #25: a legitimate repo is unaffected (writes stay in-tree)', () => {
+  const repo = makeTmp();
+  try {
+    const res = initBlackboard(repo);
+    assert.equal(res.ok, true);
+    appendBlackboardEvent(repo, { type: 'test', message: 'hello' });
+    const paths = blackboardPaths(repo);
+    assert.ok(existsSync(paths.tasks), 'tasks.json created in-tree');
+    // The blackboard dir must be a real directory under the repo, not a link.
+    assert.ok(statSync(paths.dir).isDirectory());
+    assert.ok(readFileSync(paths.events, 'utf8').includes('hello'), 'event appended in-tree');
+  } finally {
+    cleanup(repo);
   }
 });


### PR DESCRIPTION
Closes #25. Symlink/containment guard on .ijfw/blackboard reads+writes. Two adversarial review rounds (round 1 REJECT found the rotation exfil+truncate vector; round 2 APPROVE-WITH-NITS found the read-path disclosure — both folded in). Suite 3608/0 Node 22, preflight 11/11.