### PR TITLE
fix(cold-scan): seed-gate + bundle-guard the JS chokepoint (#26)

### DIFF
--- a/mcp-server/src/cold-scan-runner.mjs
+++ b/mcp-server/src/cold-scan-runner.mjs
@@ -10,6 +10,8 @@
 //   node cold-scan-runner.mjs --project-root <path> [--no-c9] [--max-files N]
 
 import { detect, writeProjectType } from './project-type-detector.js';
+import { shouldSeedProject } from './brain/seed-gate.js';
+import { isBundleInternalDeep } from './lib/project-root-guard.js';
 
 const argv = process.argv.slice(2);
 const opts = { projectRoot: null, c9Available: true, maxFiles: null };
@@ -21,6 +23,18 @@ for (let i = 0; i < argv.length; i++) {
 }
 
 if (!opts.projectRoot) process.exit(0);
+
+// issue #26 — seed-gate + bundle guard at the JS chokepoint. The bash trigger
+// (cold-scan-trigger.sh) already sources seed-gate.sh, but the installer and
+// programmatic callers spawn THIS runner directly, bypassing that wrapper. So
+// materializing .ijfw/project.type here into a marker-less dir, $HOME, a
+// signed app bundle, or an attacker-chosen IJFW_PROJECT_DIR regressed the
+// issue-#16 privacy fix and the wayland#755 bundle protection. isBundleInternalDeep
+// catches a bundle that happens to carry a marker (e.g. an Electron app's
+// package.json); shouldSeedProject enforces the real-project / homedir rule.
+if (isBundleInternalDeep(opts.projectRoot) || !shouldSeedProject(opts.projectRoot)) {
+  process.exit(0);
+}
 
 try {
   const result = detect(opts.projectRoot, {

--- a/mcp-server/src/dispatch/colon-syntax.js
+++ b/mcp-server/src/dispatch/colon-syntax.js
@@ -44,6 +44,7 @@ import { dirname, join } from 'path';
 // keeps the old precedence (ctx.projectRoot, then IJFW_PROJECT_DIR, then
 // cwd) but rejects bundle-internal candidates at every step.
 import { vetProjectRoot } from '../lib/project-root-guard.js';
+import { shouldSeedProject } from '../brain/seed-gate.js';
 
 // Recognised namespaces -- gates dispatchRun against typos.
 // v1.4.0 (F7): added 'override', 'extension', 'domain-manifest' for the
@@ -452,7 +453,13 @@ async function dispatchDetect(parsed, { projectRoot, sessionId }) {
       maxFiles: flags.maxFiles || undefined,
       sessionId,
     });
-    try { writeProjectType(projectRoot, result); } catch { /* best-effort cache */ }
+    // issue #26: projectRoot is bundle-vetted here (vetProjectRoot upstream),
+    // but was NOT seed-gated -- an MCP `ijfw_run detect:project_type` in a
+    // marker-less scratch dir still materialized .ijfw/project.type. Detection
+    // still returns to the caller; only the on-disk cache is gated.
+    if (shouldSeedProject(projectRoot)) {
+      try { writeProjectType(projectRoot, result); } catch { /* best-effort cache */ }
+    }
     return { ok: true, mode: 'sync', result };
   } catch (err) {
     return {

--- a/mcp-server/src/project-type-detector.js
+++ b/mcp-server/src/project-type-detector.js
@@ -53,6 +53,8 @@ import {
   clearScanState,
   acquireScanLock,
 } from './scan-resume.js';
+import { shouldSeedProject } from './brain/seed-gate.js';
+import { isBundleInternalDeep } from './lib/project-root-guard.js';
 
 // --- Tunables --------------------------------------------------------------
 
@@ -166,6 +168,15 @@ const FILENAME_PATTERNS = [
  */
 export function detect(projectRoot, options = {}) {
   const root = String(projectRoot || process.cwd());
+  // issue #26: detect()'s ONLY on-disk side effect is scan-state checkpointing
+  // (writeScanState/acquireScanLock on an incomplete walk). That is exactly the
+  // ".ijfw litter in a non-project dir" the seed gate exists to prevent, and it
+  // fired even when the caller gated only the project.type cache (the colon
+  // detect:project_type sync path) or didn't gate at all (domain-manifest,
+  // gate-result). Gate persistence here so every detect() caller is covered at
+  // once: detection still RETURNS its result in any dir; only the disk
+  // checkpoint is suppressed outside a real, non-bundle project.
+  const mayPersistScanState = shouldSeedProject(root) && !isBundleInternalDeep(root);
   // P3-M2: when the caller doesn't pass c9Available explicitly, run a
   // sync availability probe (existsSync of compute/fts5.js) so the
   // confidence cap auto-engages on installs that ship without the C9
@@ -209,7 +220,7 @@ export function detect(projectRoot, options = {}) {
 
   // --- Signal #4: file-tree walk (0.6 - 0.75 raw; capped 0.7 in fallback) -
   const timeBudgetMs = resolveTimeBudgetMs(options);
-  const walk = walkProject(root, { maxFiles, maxDepth: MAX_DEPTH, options, timeBudgetMs });
+  const walk = walkProject(root, { maxFiles, maxDepth: MAX_DEPTH, options, timeBudgetMs, mayPersist: mayPersistScanState });
   const treeHash = fileTreeHash(walk.fingerprint);
 
   // Manifest votes -- presence is a strong software signal.
@@ -308,7 +319,7 @@ export function detect(projectRoot, options = {}) {
   // attempts counter unsafely. If the lock is held by another live
   // writer, skip the persist -- their write covers the same forward
   // progress just as accurately.
-  if (scanIncomplete) {
+  if (scanIncomplete && mayPersistScanState) {
     const lock = acquireScanLock(root);
     if (lock) {
       try {
@@ -461,7 +472,7 @@ function readFrontmatterType(path) {
   return null;
 }
 
-function walkProject(root, { maxFiles, maxDepth, options, timeBudgetMs }) {
+function walkProject(root, { maxFiles, maxDepth, options, timeBudgetMs, mayPersist = true }) {
   const out = {
     filesScanned: 0,
     totalEstimate: 0,
@@ -602,7 +613,8 @@ function walkProject(root, { maxFiles, maxDepth, options, timeBudgetMs }) {
       // Periodic checkpoint write so a crash never loses more than
       // CHECKPOINT_EVERY files of progress. P3-H3: persist accumulated
       // partial state so the resumed walk can keep adding to it.
-      if (out.filesScanned % CHECKPOINT_EVERY === 0) {
+      // issue #26: suppressed outside a real project (no .ijfw litter).
+      if (mayPersist && out.filesScanned % CHECKPOINT_EVERY === 0) {
         try {
           writeScanState(root, {
             scan_id: newScanId(),

--- a/mcp-server/test-cold-scan-trigger.js
+++ b/mcp-server/test-cold-scan-trigger.js
@@ -271,3 +271,56 @@ test('trigger does NOT re-fire when scan-state.json present', () => {
   rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
   rmSync(home, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 });
+
+// ---------------------------------------------------------------------------
+// issue #26 — the JS cold-scan chokepoint must honor the seed gate + bundle
+// guard, matching the bash trigger (cold-scan-trigger.sh sources seed-gate.sh).
+// The installer and programmatic callers spawn the runner DIRECTLY, bypassing
+// that wrapper, so the gate has to live in the runner itself.
+// ---------------------------------------------------------------------------
+
+const NODE_BIN = process.execPath;
+
+test('issue #26: runner does NOT write project.type into a marker-less dir', () => {
+  const d = mkdtempSync(join(tmpdir(), 'ijfw-cs26-bare-'));
+  try {
+    // No project marker (.git/package.json/etc.) — the seed gate must refuse.
+    const r = spawnSync(NODE_BIN, [RUNNER, '--project-root', d], { encoding: 'utf8' });
+    assert.equal(r.status, 0, 'runner still exits 0 (silent skip)');
+    assert.equal(existsSync(join(d, '.ijfw', 'project.type')), false,
+      'no .ijfw/project.type may be materialized in a marker-less directory');
+  } finally {
+    rmSync(d, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  }
+});
+
+test('issue #26: runner DOES write project.type in a real project (control)', () => {
+  const d = mkdtempSync(join(tmpdir(), 'ijfw-cs26-proj-'));
+  try {
+    writeFileSync(join(d, 'package.json'), '{"name":"p","version":"0.0.0"}\n');
+    const r = spawnSync(NODE_BIN, [RUNNER, '--project-root', d], { encoding: 'utf8' });
+    assert.equal(r.status, 0);
+    assert.equal(existsSync(join(d, '.ijfw', 'project.type')), true,
+      'a real project (has a marker) still gets its cached project.type');
+  } finally {
+    rmSync(d, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  }
+});
+
+test('issue #26: runner refuses a signed-bundle interior even with a marker', () => {
+  const base = mkdtempSync(join(tmpdir(), 'ijfw-cs26-bundle-'));
+  try {
+    // Electron-style: <base>/App.app/Contents/... with a real Contents dir so
+    // the fs-backed bundle check fires, and a package.json marker inside.
+    mkdirSync(join(base, 'App.app', 'Contents'), { recursive: true });
+    const inner = join(base, 'App.app', 'Contents', 'Resources', 'app');
+    mkdirSync(inner, { recursive: true });
+    writeFileSync(join(inner, 'package.json'), '{"name":"electron","version":"1"}\n');
+    const r = spawnSync(NODE_BIN, [RUNNER, '--project-root', inner], { encoding: 'utf8' });
+    assert.equal(r.status, 0);
+    assert.equal(existsSync(join(inner, '.ijfw', 'project.type')), false,
+      'writing .ijfw inside a signed bundle would break the codesign seal (wayland#755)');
+  } finally {
+    rmSync(base, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  }
+});

--- a/mcp-server/test-colon-dispatch.js
+++ b/mcp-server/test-colon-dispatch.js
@@ -14,7 +14,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -167,6 +167,34 @@ test('dispatchRun detect:project_type returns real detection result', async () =
     assert.equal(typeof r.result.confidence, 'number');
     assert.equal(Array.isArray(r.result.secondary_types), true);
     assert.equal(typeof r.result.scan_incomplete, 'boolean');
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+// issue #26: the MCP detect:project_type sync path must seed-gate the on-disk
+// cache. Detection still RETURNS to the caller in any dir; only the
+// .ijfw/project.type write is gated (matches the runner + bash trigger).
+test('issue #26: detect:project_type does NOT cache .ijfw/project.type in a marker-less dir', async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'ijfw-colon-detect-bare-'));
+  try {
+    const r = await dispatchRun(parseColonCommand('detect:project_type'), { projectRoot });
+    assert.equal(r.ok, true, 'detection still returns a result');
+    assert.equal(existsSync(join(projectRoot, '.ijfw', 'project.type')), false,
+      'no on-disk cache may be written in a marker-less directory');
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test('issue #26: detect:project_type DOES cache in a real project (control)', async () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'ijfw-colon-detect-proj-'));
+  try {
+    writeFileSync(join(projectRoot, 'package.json'), '{"name":"p","version":"0.0.0"}\n');
+    const r = await dispatchRun(parseColonCommand('detect:project_type'), { projectRoot });
+    assert.equal(r.ok, true);
+    assert.equal(existsSync(join(projectRoot, '.ijfw', 'project.type')), true,
+      'a real project caches its project.type as before');
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }

--- a/mcp-server/test-project-type-detection.js
+++ b/mcp-server/test-project-type-detection.js
@@ -190,12 +190,29 @@ function readFileNames(dir) {
 
 test('Test 8: scan_incomplete=true + scan-state present persists for prompt', () => {
   const root = tmpDir('incomp');
+  // issue #26: scan-state persistence is now gated on shouldSeedProject, so a
+  // real project marker is required for the checkpoint to be written (a real
+  // project being scanned always has one). Detection returns scan_incomplete
+  // regardless; only the on-disk checkpoint is seed-gated.
+  w(root, 'package.json', '{"name":"incomp","version":"0.0.0"}\n');
   for (let i = 1; i <= 20; i++) w(root, `src/f${i}.js`, '//\n');
   const r = detect(root, { maxFiles: 3, resume: false });
   assert.equal(r.scan_incomplete, true);
   const state = loadScanState(root);
   assert.ok(state, 'scan-state file must be present so downstream consumers prompt');
   assert.equal(state.incomplete, true);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('issue #26: detect() does NOT persist scan-state in a marker-less dir', () => {
+  const root = tmpDir('nolitter');
+  // No project marker -> seed gate refuses. Force an incomplete walk (maxFiles
+  // low, >CHECKPOINT boundary) that WOULD checkpoint in a real project.
+  for (let i = 1; i <= 20; i++) w(root, `src/f${i}.js`, '//\n');
+  const r = detect(root, { maxFiles: 3, resume: false });
+  assert.equal(r.scan_incomplete, true, 'detection still runs + returns the incomplete flag');
+  assert.equal(loadScanState(root), null, 'no scan-state may be written in a marker-less dir');
+  assert.equal(existsSync(join(root, '.ijfw')), false, 'no .ijfw dir may be created as litter');
   rmSync(root, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
Closes #26. Seed-gate + bundle-guard the JS cold-scan chokepoint (runner + detect() persistence + colon cache). Two adversarial review rounds (round 1 APPROVE-WITH-NITS found the detect() scan-state litter path; round 2 APPROVE). Suite 3609/0 Node 22, preflight 11/11.