### PR TITLE
fix(release): lockstep all 9 version surfaces + enforce in CI

### DIFF
--- a/claude/.claude-plugin/marketplace.json
+++ b/claude/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "ijfw",
       "source": "./",
       "description": "AI efficiency framework. Smarter output, intelligent routing, persistent memory, context discipline, project workflows. One install. Zero config. It just fucking works.",
-      "version": "1.5.6",
+      "version": "1.6.4",
       "author": { "name": "Sean Donahoe", "url": "https://github.com/TheRealSeanDonahoe" },
       "contributors": [{ "name": "Ferrox Labs", "url": "https://ferroxlabs.com" }],
       "license": "MIT",

--- a/codex/.agents/plugins/marketplace.json
+++ b/codex/.agents/plugins/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ijfw",
-  "version": "1.5.6",
+  "version": "1.6.4",
   "description": "IJFW -- It Just Fucking Works. 19 workflow skills + 22 command aliases + 6 hook events + persistent project memory, project teams, swarm orchestration, and design intelligence. Native Codex plugin with full parity to the Claude Code and Gemini bundles.",
   "author": "Sean Donahoe",
   "contributors": ["Ferrox Labs (https://ferroxlabs.com)"],

--- a/gemini/extensions/ijfw/gemini-extension.json
+++ b/gemini/extensions/ijfw/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "ijfw",
-  "version": "1.5.6",
+  "version": "1.6.4",
   "description": "IJFW -- AI efficiency layer for Gemini CLI. 19 workflow skills, 11-event hooks, persistent project memory via MCP. Native policy engine + checkpointing integration. One install layer across 15 AI coding platforms.",
   "contextFileName": "IJFW.md",
   "mcpServers": {

--- a/hermes/plugins/ijfw/plugin.yaml
+++ b/hermes/plugins/ijfw/plugin.yaml
@@ -1,5 +1,5 @@
 name: ijfw
-version: 1.5.1
+version: 1.6.4
 description: IJFW -- memory hydration, vague-prompt nudge, destructive-command guard, session receipts. Hermes shim delegates to Wayland plugin source.
 author: Sean Donahoe
 entry: __init__.py

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # check-all.sh -- single gate for IJFW CI + publish-day health.
 #
-# Runs: banned-char lint, mcp-server unit suite, installer syntax check.
-# Exits 0 only when every check passes. Fail-fast.
+# Runs: banned-char lint, version lockstep, mcp-server unit suite, installer
+# syntax check. Exits 0 only when every check passes. Fail-fast.
 
 set -euo pipefail
 
@@ -65,6 +65,21 @@ if [ "$HITS" -gt 0 ]; then
   exit 1
 fi
 ok "banned-char lint clean"
+
+echo
+echo "== version lockstep =="
+# Every release-versioned surface (the 2 npm packages + all 7 platform plugin/
+# marketplace manifests across claude/codex/gemini/hermes/wayland) must carry the
+# same version. This gate previously ran ONLY in the manual scripts/e2e-smoke.sh
+# and checked just 3 surfaces, so gemini + both marketplaces drifted to 1.5.6 and
+# the hermes/wayland plugin.yaml to 1.5.1 while the code shipped 1.6.4. Wired here
+# so CI enforces all 9 every run. Cheap + fail-fast: runs before the ~5min suite.
+if bash scripts/check-version-lockstep.sh; then
+  ok "release version lockstep"
+else
+  fail "release version lockstep (see drift above)"
+  exit 1
+fi
 
 echo
 echo "== mcp-server unit tests =="

--- a/scripts/check-version-lockstep.sh
+++ b/scripts/check-version-lockstep.sh
@@ -1,45 +1,113 @@
 #!/usr/bin/env bash
 # scripts/check-version-lockstep.sh
 #
-# F4.4 + Wave 2 Lens 3 (F-C-5, F-C-7): assert installer / mcp-server /
-# codex plugin versions match. Codex doctor's "plugin metadata" check trusts
-# this invariant -- half-bumped release silently breaks the doctor for users.
+# F4.4 + Wave 2 Lens 3 (F-C-5, F-C-7): assert every RELEASE-versioned surface
+# carries the same version. Codex doctor's "plugin metadata" check trusts this
+# invariant -- a half-bumped release silently breaks the doctor for users, and
+# a marketplace/plugin manifest stuck a version behind mislabels the listing
+# users install from (Hermes copies its plugin.yaml to ~/.hermes verbatim).
 #
-# Provides IJFW-styled error surface (no raw Node stack traces) and a
-# "likely target" hint when drift is detected.
+# Coverage: gemini + both marketplaces were drifted at 1.5.6, and the hermes +
+# wayland plugin.yaml manifests at 1.5.1, while the code shipped 1.6.4 -- because
+# the old gate checked only 3 JSON surfaces AND ran only in the manual
+# scripts/e2e-smoke.sh. This now covers ALL NINE release surfaces:
+#   1. installer/package.json                        (npm @ijfw/install version)
+#   2. mcp-server/package.json                       (npm @ijfw/memory-server version)
+#   3. claude/.claude-plugin/plugin.json             (Claude Code plugin manifest)
+#   4. claude/.claude-plugin/marketplace.json        (Claude marketplace -> .plugins[0])
+#   5. codex/.codex-plugin/plugin.json               (Codex plugin manifest)
+#   6. codex/.agents/plugins/marketplace.json        (Codex marketplace listing)
+#   7. gemini/extensions/ijfw/gemini-extension.json  (Gemini extension manifest)
+#   8. hermes/plugins/ijfw/plugin.yaml               (Hermes plugin manifest; SHIPS verbatim)
+#   9. wayland/plugins/ijfw/plugin.yaml              (Wayland plugin source manifest)
+#
+# NOT covered (deliberate): the repo root package.json is the private
+# "ijfw-workspace" stub (private:true, version 1.0.0) -- not a release surface.
+#
+# IJFW-styled error surface (no raw Node stack traces) + a "likely target" hint.
 
 set -euo pipefail
 REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-read_ver () {
-  local label="$1" pkg="$2"
-  if [ ! -f "$pkg" ]; then
-    echo "[version-lockstep] $label manifest MISSING: $pkg" >&2
-    exit 1
-  fi
+# read_json_ver <label> <manifest-path> [<node-accessor>]
+# accessor defaults to `m.version`; pass a JS expression on `m` for nested
+# surfaces (the Claude marketplace nests it under plugins[0]). The manifest path
+# is passed via argv (NOT string-interpolated) so a checkout path containing a
+# quote can't break the require().
+read_json_ver () {
+  local label="$1" pkg="$2" accessor="${3:-m.version}"
   local v
-  v=$(node -p "require('$REPO_ROOT/$pkg').version" 2>/dev/null) || {
-    echo "[version-lockstep] $label manifest UNPARSEABLE: $pkg" >&2
+  v=$(node -e "const m=require(process.argv[1]); const v=($accessor); if(v==null){process.exit(3)} process.stdout.write(String(v))" "$REPO_ROOT/$pkg" 2>/dev/null) || {
+    echo "[version-lockstep] $label manifest UNPARSEABLE or missing version: $pkg" >&2
     exit 1
   }
   printf '%s' "$v"
 }
 
-installer=$(read_ver "installer"      "installer/package.json")
-mcp=$(read_ver       "mcp-server"     "mcp-server/package.json")
-codex=$(read_ver     "codex plugin"   "codex/.codex-plugin/plugin.json")
+# read_yaml_ver <label> <manifest-path>
+# Reads the first top-level `version:` key. Zero-dep (no YAML lib): strips
+# optional surrounding quotes/whitespace. Sufficient for these flat manifests.
+read_yaml_ver () {
+  local label="$1" pkg="$2" v
+  v=$(awk -F: '/^version:[[:space:]]*/ {sub(/^version:[[:space:]]*/,""); gsub(/["'\''[:space:]]/,""); print; exit}' "$pkg")
+  if [ -z "$v" ]; then
+    echo "[version-lockstep] $label manifest missing a top-level version: $pkg" >&2
+    exit 1
+  fi
+  printf '%s' "$v"
+}
 
-if [ "$installer" != "$mcp" ] || [ "$installer" != "$codex" ]; then
-  echo "[version-lockstep] DRIFT detected:" >&2
-  echo "  installer/package.json:            $installer" >&2
-  echo "  mcp-server/package.json:           $mcp" >&2
-  echo "  codex/.codex-plugin/plugin.json:   $codex" >&2
+# read_ver <label> <path> <kind> [<accessor>]  -- kind = json | yaml
+read_ver () {
+  local label="$1" pkg="$2" kind="$3" accessor="${4:-}"
+  if [ ! -f "$pkg" ]; then
+    echo "[version-lockstep] $label manifest MISSING: $pkg" >&2
+    exit 1
+  fi
+  case "$kind" in
+    json) read_json_ver "$label" "$pkg" "$accessor" ;;
+    yaml) read_yaml_ver "$label" "$pkg" ;;
+    *)    echo "[version-lockstep] internal: unknown kind '$kind' for $pkg" >&2; exit 1 ;;
+  esac
+}
+
+# label|path|kind|accessor  (accessor only used for json; omit for m.version)
+SURFACES=(
+  "installer|installer/package.json|json"
+  "mcp-server|mcp-server/package.json|json"
+  "claude plugin|claude/.claude-plugin/plugin.json|json"
+  "claude marketplace|claude/.claude-plugin/marketplace.json|json|m.plugins[0].version"
+  "codex plugin|codex/.codex-plugin/plugin.json|json"
+  "codex marketplace|codex/.agents/plugins/marketplace.json|json"
+  "gemini extension|gemini/extensions/ijfw/gemini-extension.json|json"
+  "hermes plugin|hermes/plugins/ijfw/plugin.yaml|yaml"
+  "wayland plugin|wayland/plugins/ijfw/plugin.yaml|yaml"
+)
+
+ref_ver=""
+drift=0
+report=""
+for entry in "${SURFACES[@]}"; do
+  IFS='|' read -r label path kind accessor <<< "$entry"
+  v=$(read_ver "$label" "$path" "$kind" "$accessor")
+  report+="$(printf '  %-44s %s' "$path:" "$v")"$'\n'
+  if [ -z "$ref_ver" ]; then
+    ref_ver="$v"
+  elif [ "$v" != "$ref_ver" ]; then
+    drift=1
+  fi
+done
+
+if [ "$drift" -ne 0 ]; then
+  echo "[version-lockstep] DRIFT detected across release surfaces:" >&2
+  printf '%s' "$report" >&2
   echo "" >&2
-  target=$(printf '%s\n%s\n%s\n' "$installer" "$mcp" "$codex" | sort -V | tail -1)
+  target=$(printf '%s' "$report" | awk '{print $NF}' | sort -V | tail -1)
   echo "  likely target (highest semver): $target" >&2
   echo "" >&2
-  echo "Fix: bump all three to the same version before publishing." >&2
+  echo "Fix: bump every surface above to the same version before publishing." >&2
   exit 1
 fi
-echo "[version-lockstep] OK: all three at $installer"
+
+echo "[version-lockstep] OK: all 9 release surfaces at $ref_ver"

--- a/scripts/e2e-smoke.sh
+++ b/scripts/e2e-smoke.sh
@@ -173,13 +173,14 @@ else
 fi
 
 # ============================================================
-# Version lockstep gate (F4.4 -- installer/mcp-server/codex must match)
+# Version lockstep gate (F4.4 -- all 9 release surfaces must match; also
+# wired into check-all.sh so CI enforces it every run, not just here)
 # ============================================================
 hdr "Version lockstep gate"
 if (cd "$REPO_ROOT" && bash scripts/check-version-lockstep.sh); then
-  pass "version-lockstep: installer/mcp-server/codex versions match"
+  pass "version-lockstep: all release surfaces match"
 else
-  fail "version-lockstep: drift detected between installer/mcp-server/codex package versions"
+  fail "version-lockstep: drift detected across release surfaces (see output above)"
 fi
 
 # ============================================================

--- a/wayland/plugins/ijfw/plugin.yaml
+++ b/wayland/plugins/ijfw/plugin.yaml
@@ -1,5 +1,5 @@
 name: ijfw
-version: 1.5.1
+version: 1.6.4
 description: IJFW -- memory hydration, vague-prompt nudge, destructive-command guard, session receipts.
 author: Sean Donahoe
 entry: __init__.py


### PR DESCRIPTION
Lockstep all 9 release-versioned surfaces to 1.6.4 and enforce it in CI (wired check-version-lockstep.sh into check-all.sh). Fixes the silent drift: gemini + both marketplaces were at 1.5.6, hermes + wayland plugin.yaml at 1.5.1. Two adversarial review rounds (round 1 REJECT caught the hermes/wayland YAML surfaces a JSON-only gate could never see; round 2 APPROVE). Suite 3614/0 Node 22, preflight 11/11, per-surface negative control green on all 9. Overwatch: Sean confirmed gemini locksteps; I included the 4 other same-class drifted surfaces — narrow if any has independent cadence.