### PR TITLE
harden(publish): release-env gate + tag-version assert + dist-tag fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,12 @@ jobs:
     name: Publish to npm
     needs: [preflight, check-all]
     runs-on: ubuntu-latest
+    # WHO-can-publish gate (supply-chain hardening): the `release` environment is
+    # protected in repo settings with a required reviewer, so a v* tag -- no
+    # matter who pushes it -- pauses here until a human approves the deployment
+    # before any npm publish runs. Pairs with the tag-creation ruleset (only the
+    # release actor may create v*), applied by Overwatch outside this workflow.
+    environment: release
     permissions:
       contents: write
       id-token: write
@@ -103,6 +109,31 @@ jobs:
         working-directory: installer
         run: npm run build
 
+      # Supply-chain guard: the pushed tag MUST match the version being
+      # published. Without this, `git tag v9.9.9` on a commit whose
+      # package.json says 1.6.5 would publish 1.6.5 under a GitHub Release
+      # titled v9.9.9 (the post-publish smoke caught it only AFTER the package
+      # went live). check-all's version-lockstep gate already proves all 9
+      # in-repo surfaces agree; this asserts the TAG agrees with them too, so
+      # tag == every published version. TAG_REF via env (never inlined into the
+      # run: script) per GitHub Actions injection guidance.
+      - name: Assert tag matches package.json version
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG_REF#v}"
+          INSTALLER_VER=$(node -p "require('./installer/package.json').version")
+          MCP_VER=$(node -p "require('./mcp-server/package.json').version")
+          if [ "$VERSION" != "$INSTALLER_VER" ]; then
+            echo "::error::tag $TAG_REF (version $VERSION) != installer/package.json ($INSTALLER_VER)"
+            exit 1
+          fi
+          if [ "$VERSION" != "$MCP_VER" ]; then
+            echo "::error::tag $TAG_REF (version $VERSION) != mcp-server/package.json ($MCP_VER)"
+            exit 1
+          fi
+          echo "tag <-> package.json version match: $VERSION"
+
       # npm publish triggers prepublishOnly, which re-runs the full preflight
       # INSIDE this job -- including the fail-closed gitleaks gate. The gate
       # jobs above install gitleaks for themselves; this job needs it too or
@@ -121,11 +152,25 @@ jobs:
         env:
           TAG_REF: ${{ github.ref_name }}
         run: |
-          if echo "$TAG_REF" | grep -q -- '-rc\.'; then
-            DIST_TAG="next"
-          else
-            DIST_TAG="latest"
+          # First, STRICTLY validate the tag shape. Shell `case` globs use `*`,
+          # which matches dots/letters -- so `v[0-9]*.[0-9]*.[0-9]*` would wrongly
+          # accept `v1.2.3.4` / `v1.2.3extra` and route them to `latest`. An
+          # anchored regex refuses anything that isn't vMAJOR.MINOR.PATCH with an
+          # optional -prerelease, so a malformed tag can never default to `latest`.
+          if [[ ! "$TAG_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::tag '$TAG_REF' is not a vMAJOR.MINOR.PATCH[-prerelease] release tag; refusing to publish"
+            exit 1
           fi
+          # SemVer: a hyphen after MAJOR.MINOR.PATCH introduces a prerelease
+          # (1.7.0-rc.1, 1.7.0-beta.2, 1.7.0-alpha.1, ...). NONE may ship to the
+          # `latest` dist-tag -- `npm install @ijfw/install` must only ever
+          # resolve a STABLE release. The old check matched ONLY `-rc.`, so a
+          # `-beta`/`-alpha` tag silently shipped to `latest`. Now: stable ->
+          # latest, ANY prerelease -> next.
+          case "$TAG_REF" in
+            *-*) DIST_TAG="next"   ;; # any prerelease suffix (shape already validated)
+            *)   DIST_TAG="latest" ;; # clean stable release
+          esac
           echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
           echo "Publishing dist-tag: $DIST_TAG"
 

--- a/docs/CI-PUBLISH.md
+++ b/docs/CI-PUBLISH.md
@@ -4,6 +4,48 @@
 
 **Status:** Legacy. Active publish flow: GitHub Actions. See `.github/workflows/publish.yml`.
 
+## ⚠️ Current pipeline (GitHub Actions) — operational notes that OVERRIDE the legacy content below
+
+The active publish path is `.github/workflows/publish.yml` (GitHub Actions), NOT the GitLab
+flow described further down. What differs operationally:
+
+- **Auth is a GRANULAR npm access token** stored as the `NPM_TOKEN` repo secret, scoped to
+  ONLY `@ijfw/install` + `@ijfw/memory-server` (read-write). Provenance is still attached via
+  `id-token: write`. The legacy "No NPM_TOKEN secret / nothing to rotate" line below is
+  **obsolete** for the GitHub flow.
+  - **TOKEN ROTATION — expires ~2026-10-08 (90-day token).** Rotate BEFORE then or the release
+    job fails at `npm publish`. Regenerate a granular token at npmjs.com with the SAME
+    two-package scope (read-write), then update the `NPM_TOKEN` secret under
+    FerroxLabs/ijfw → Settings → Secrets and variables → Actions. Do **not** touch the
+    account's other / classic tokens (shared with unrelated repos).
+- **Publish is gated on the protected `release` environment** (required reviewer): a `v*` tag,
+  regardless of who pushes it, pauses for human approval before any `npm publish` runs.
+- **Tag ↔ version assert:** the publish job fails if the pushed tag doesn't equal
+  `installer/package.json` and `mcp-server/package.json` versions. `check-all.sh`'s
+  version-lockstep gate additionally proves all 9 in-repo release surfaces agree, so a green
+  release means tag == every published/manifest version.
+- **Strict dist-tag rule:** only a clean stable `vMAJOR.MINOR.PATCH` tag ships to `latest`;
+  any prerelease (`-rc` / `-beta` / `-alpha` / ...) ships to `next`; a malformed tag is
+  refused, never defaulted to `latest`.
+
+### Verify the `release` environment protection IS applied (do this once, and after any settings change)
+
+The `environment: release` gate is only as strong as the repo-settings protection behind it.
+A workflow referencing an environment that has **no protection rules auto-creates it
+unprotected**, so the approval pause silently disappears. Confirm the protection is live:
+
+```bash
+# Required reviewers must be non-empty, or a v* tag publishes with NO human approval:
+gh api repos/FerroxLabs/ijfw/environments/release \
+  --jq '{name, reviewers: (.protection_rules[]? | select(.type=="required_reviewers") | .reviewers | length)}'
+# Expect reviewers >= 1. If the environment 404s or reviewers is 0/absent, the gate is a no-op --
+# add a required reviewer under Settings -> Environments -> release before the next release.
+```
+
+Also confirm the tag-creation ruleset restricts `v*` creation to the release actor
+(`gh api repos/FerroxLabs/ijfw/rulesets` -> a ruleset targeting `refs/tags/v*` with a
+`creation` restriction). Both are admin-owned settings, not enforceable from the workflow.
+
 ## How it works
 
 On `git push` of a tag matching `^v\d+\.\d+\.\d+$`, GitLab CI's `publish` stage runs two jobs in parallel — `publish:mcp-server` and `publish:installer`. Each job:


### PR DESCRIPTION
## Publish-hardening: release-env gate + tag↔version assert + dist-tag fix

**Overwatch review requested (release/publish-security infra — do not auto-merge).**
Workflow + docs only. No code, no admin/settings edits.

### What this delivers (per the publish-hardening card)
1. **WHO-can-publish gate** — the `publish` job now runs under `environment: release`.
   A `v*` tag, no matter who pushes it, pauses for required-reviewer approval before any
   `npm publish`. (The environment *protection itself* is admin-configured in repo
   settings, outside this workflow — see the audit block below.)
2. **Tag ↔ version assert** — a pre-publish step fails the job unless the pushed tag
   equals both `installer/package.json` and `mcp-server/package.json` versions.
   Combined with the 9-surface version-lockstep gate now in `check-all.sh` (landed in
   #35, which this branch is rebased onto), a green release means tag == every one of
   the 9 in-repo release surfaces, including codex.
3. **dist-tag fix** — an anchored regex validates the tag shape *first*
   (`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$`), then stable→`latest`, ANY
   prerelease→`next`, malformed→**refused**. The old `case` globs would have routed
   `v1.2.3.4` / `v1.2.3extra` to `latest`; the old `-rc.`-only match shipped
   `-beta`/`-alpha` to `latest`. Both closed.
4. **docs/CI-PUBLISH.md** — current-pipeline callout: the `NPM_TOKEN` **~2026-10-08
   (90-day) rotation deadline**, plus a `gh api` settings-audit block to verify the
   release-env required reviewer (≥1) and the `refs/tags/v*` creation ruleset are
   actually applied (the workflow cannot self-enforce either).

### Verification
- `check-all.sh` green on the rebased tree (banned-char, 9-surface lockstep, full
  mcp-server suite 3579/0/35, installer syntax, design skills, JSON, hook timeouts,
  platform drift, python). This PR touches no code, so the suite is orthogonal.
- dist-tag + assert logic unit-tested across all shapes: `v1.6.4`/`v2.0.0`→latest;
  `-rc.1`/`-beta.2`/`-alpha.1`→next; `v1.2.3.4`/`v1.2.3extra`/`v1.2` /`"v1.2.3 ; rm -rf /"`
  /newline-injection→refused.
- Two adversarial review rounds (reviewer tasked to refute): round 1 APPROVE-WITH-NITS
  (lockstep-staleness → fixed by rebase; malformed-tag glob → strict regex;
  unprotected-env-auto-create → docs audit block); round 2 APPROVE, no new issues,
  injection clean (`TAG_REF` via `env:`, not inlined).

### For Overwatch (admin authority — NOT in this PR)
The workflow references `environment: release`, but a referenced environment with no
protection rules **auto-creates unprotected** — the approval pause silently disappears.
Please confirm (audit block is in the doc):
- `repos/FerroxLabs/ijfw/environments/release` has required reviewers ≥ 1;
- a ruleset restricts `refs/tags/v*` **creation** to the release actor.

Out of scope per the card: token/OIDC migration, classic-token cleanup, and the
env-protection + tag-creation *settings* themselves (admin).
