### PR TITLE
release: v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [1.6.5] - 2026-07-11 - Publish-path hardening and version lockstep across all release surfaces
+
+A release-safety pass on the publish pipeline and the JS chokepoints that feed
+it. No user-facing behavior changes — every fix tightens supply-chain integrity,
+version consistency, or the cold-scan/blackboard guards so a half-formed release
+can never ship.
+
+### Fixed
+
+- **Publish is gated behind a protected `release` environment.** The `v*` tag
+  workflow now pauses for a required human reviewer before any `npm publish`
+  runs, asserts the pushed tag matches `package.json` (tag `!=` version refuses
+  to publish), and routes prereleases to the `next` dist-tag instead of ever
+  shipping them to `latest`.
+- **All nine release surfaces are version-locked and enforced in CI.** The
+  lockstep gate now covers every versioned manifest — installer, mcp-server,
+  the Claude/Codex plugin + marketplace manifests, the Gemini extension, and the
+  Hermes/Wayland `plugin.yaml` manifests — so a half-bumped release fails the
+  gate instead of drifting a listing a version behind.
+- **The gitleaks preflight gate runs `--redact`** so a matched secret's value
+  never lands in a CI artifact or log.
+- **Cold-scan JS chokepoint is seed-gated and bundle-guarded**, closing the last
+  path by which a scan could author config outside a real project root.
+- **Blackboard reads and writes are symlink/containment-guarded**, and a read
+  cache that served stale task state on an mtime-quantum collision now reads
+  through correctly.
+- **Codex config no longer clobbers** a pre-existing setup on install.
+
+### Notes
+
+- Installed copies pick this up on the next `ijfw update` (or a fresh
+  `npx @ijfw/install`).
+
 ## [1.6.4] - 2026-07-10 - Reject bundle-internal project roots (never write inside a signed app)
 
 IJFW could adopt a *writable* directory as its project root even when that

--- a/claude/.claude-plugin/marketplace.json
+++ b/claude/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "ijfw",
       "source": "./",
       "description": "AI efficiency framework. Smarter output, intelligent routing, persistent memory, context discipline, project workflows. One install. Zero config. It just fucking works.",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "author": { "name": "Sean Donahoe", "url": "https://github.com/TheRealSeanDonahoe" },
       "contributors": [{ "name": "Ferrox Labs", "url": "https://ferroxlabs.com" }],
       "license": "MIT",

--- a/claude/.claude-plugin/plugin.json
+++ b/claude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ijfw",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "AI efficiency framework. Smarter output, intelligent routing, persistent memory, context discipline, project workflows. One install. Zero config. It just fucking works.",
   "author": {
     "name": "Sean Donahoe",

--- a/codex/.agents/plugins/marketplace.json
+++ b/codex/.agents/plugins/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "ijfw",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "IJFW -- It Just Fucking Works. 19 workflow skills + 22 command aliases + 6 hook events + persistent project memory, project teams, swarm orchestration, and design intelligence. Native Codex plugin with full parity to the Claude Code and Gemini bundles.",
   "author": "Sean Donahoe",
   "contributors": ["Ferrox Labs (https://ferroxlabs.com)"],

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ijfw",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "IJFW -- AI efficiency layer for Codex. 19 workflow skills, 22 command aliases, 6 hook events, persistent project memory via MCP, project teams, swarm orchestration, and design intelligence. One install layer across 15 AI coding platforms.",
   "author": "Sean Donahoe",
   "contributors": [

--- a/gemini/extensions/ijfw/gemini-extension.json
+++ b/gemini/extensions/ijfw/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "ijfw",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "IJFW -- AI efficiency layer for Gemini CLI. 19 workflow skills, 11-event hooks, persistent project memory via MCP. Native policy engine + checkpointing integration. One install layer across 15 AI coding platforms.",
   "contextFileName": "IJFW.md",
   "mcpServers": {

--- a/hermes/plugins/ijfw/plugin.yaml
+++ b/hermes/plugins/ijfw/plugin.yaml
@@ -1,5 +1,5 @@
 name: ijfw
-version: 1.6.4
+version: 1.6.5
 description: IJFW -- memory hydration, vague-prompt nudge, destructive-command guard, session receipts. Hermes shim delegates to Wayland plugin source.
 author: Sean Donahoe
 entry: __init__.py

--- a/installer/package-lock.json
+++ b/installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ijfw/install",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ijfw/install",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "license": "MIT",
       "bin": {
         "ijfw": "dist/ijfw.js",

--- a/installer/package.json
+++ b/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ijfw/install",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "One-command installer for IJFW -- the AI efficiency layer. One install, every AI coding agent, zero config.",
   "type": "module",
   "bin": {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ijfw/memory-server",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ijfw/memory-server",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^11.5.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ijfw/memory-server",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Cross-platform persistent memory server for IJFW. 14 MCP tools (memory + admin/update + brain). Works with 15 platforms: 14 via MCP (Claude Code, Codex, Gemini CLI, Cursor, Windsurf, Copilot, Hermes, Wayland, OpenCode, QwenCode, Cline, KimiCode, OpenClaw, Antigravity) plus Aider via the rules-only tier.",
   "author": "Sean Donahoe",
   "contributors": [

--- a/wayland/plugins/ijfw/plugin.yaml
+++ b/wayland/plugins/ijfw/plugin.yaml
@@ -1,5 +1,5 @@
 name: ijfw
-version: 1.6.4
+version: 1.6.5
 description: IJFW -- memory hydration, vague-prompt nudge, destructive-command guard, session receipts.
 author: Sean Donahoe
 entry: __init__.py


### PR DESCRIPTION
## Summary

Cuts **v1.6.5** by propagating the version across all nine version-locked release surfaces (installer, mcp-server, Claude/Codex plugin + marketplace manifests, Gemini extension, Hermes/Wayland `plugin.yaml`), the two `package-lock.json` self-version fields, and a new CHANGELOG entry.

No code changes. This releases the seven publish-hardening and lockstep commits already merged to `main` since v1.6.4:

- release-environment publish gate + tag↔version assertion + dist-tag routing (#36)
- lockstep all 9 version surfaces, enforced in CI (#35)
- gitleaks preflight `--redact` (#27/#30)
- cold-scan seed-gate + bundle-guard (#26/#29)
- blackboard symlink/containment guard + stale read-cache fix (#24/#25/#28)
- codex clobber fix (#23)

The root `package.json` (private `ijfw-workspace` stub) stays at 1.0.0 by design.

## Verification

`scripts/check-all.sh` is green: banned-char lint, 9-surface version lockstep, full mcp-server unit suite (0 failures), installer `npm ci` + build + syntax, platform-drift gate, and plugin Python syntax.