### PR TITLE
fix(atomic-io): retry rename on transient Windows EPERM/EBUSY

### DIFF
--- a/mcp-server/src/dream/state-file.js
+++ b/mcp-server/src/dream/state-file.js
@@ -17,10 +17,9 @@
 // Pattern lift from sibling project Wayland's
 // `crates/wcore-memory/src/consolidate.rs` DreamThrottle.
 
-import {
-  existsSync, readFileSync, writeFileSync, mkdirSync, renameSync,
-} from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { writeAtomic } from '../lib/atomic-io.js';
 
 const DEFAULT = { version: 1, last_run_at: null, runs_total: 0, stages: {} };
 
@@ -42,10 +41,11 @@ export function readDreamState(root) {
 
 export function writeDreamState(root, state) {
   const p = pathOf(root);
-  mkdirSync(join(root, '.ijfw'), { recursive: true });
-  const tmp = p + '.tmp';
-  writeFileSync(tmp, JSON.stringify(state, null, 2));
-  renameSync(tmp, p);
+  // Delegate to the shared atomic writer: randomized tmp name (no fixed-name
+  // collisions across concurrent runs / stale crash leftovers) + Windows
+  // rename-retry that survives transient EPERM/EBUSY from AV or the Search
+  // indexer. writeAtomic ensures the .ijfw dir exists.
+  writeAtomic(p, JSON.stringify(state, null, 2));
 }
 
 export function markStageStarted(root, stage) {

--- a/mcp-server/src/lib/atomic-io.js
+++ b/mcp-server/src/lib/atomic-io.js
@@ -71,7 +71,7 @@ export function writeAtomic(targetPath, data, opts = {}) {
     closeSync(fd);
     fd = null;
 
-    renameSync(tmp, abs);
+    renameWithRetry(tmp, abs);
 
     if (fsyncDir) {
       try {
@@ -177,6 +177,33 @@ function sleepSync(ms) {
   const sab = new SharedArrayBuffer(4);
   const view = new Int32Array(sab);
   Atomics.wait(view, 0, 0, ms);
+}
+
+// Windows-safe rename. On NTFS a rename over an existing file transiently
+// fails with EPERM/EACCES/EBUSY when antivirus, the Search indexer, or another
+// process momentarily holds a handle on src or dest -- the classic
+// "EPERM: operation not permitted, rename '<x>.tmp' -> '<x>'". POSIX rename(2)
+// is atomic and does not exhibit this, so on non-Windows we rename once and
+// return. On Windows we retry a bounded number of times with exponential
+// backoff; only the known-transient codes are retried, everything else
+// rethrows immediately so real errors are not masked.
+const RENAME_TRANSIENT = new Set(['EPERM', 'EACCES', 'EBUSY', 'EEXIST']);
+function renameWithRetry(src, dest, { maxAttempts = 10, baseDelayMs = 10, maxDelayMs = 250 } = {}) {
+  if (!IS_WIN) { renameSync(src, dest); return; }
+  let lastErr;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      renameSync(src, dest);
+      return;
+    } catch (e) {
+      lastErr = e;
+      if (!RENAME_TRANSIENT.has(e.code)) throw e;
+      if (attempt < maxAttempts - 1) {
+        sleepSync(Math.min(baseDelayMs * (2 ** attempt), maxDelayMs));
+      }
+    }
+  }
+  throw lastErr;
 }
 
 // Log rotation -- caller of writeAtomic for log files invokes this first.


### PR DESCRIPTION
## Summary

Harden atomic file writes against the intermittent Windows `EPERM`/`EBUSY` that occurs when antivirus or the Search indexer momentarily holds a handle on a rename target. This surfaced in the wild as the dream cycle failing to persist `.ijfw/.dream-state-v2.json`:

```
wiki-compile: EPERM: operation not permitted, rename
  '...\.ijfw\.dream-state-v2.json.tmp' -> '...\.ijfw\.dream-state-v2.json'
```

## Root cause

Two independent weaknesses with the same failure mode:

1. **`src/dream/state-file.js` `writeDreamState()`** rolled its own write with a **fixed** tmp name (`p + '.tmp'`) and a bare `renameSync` with no retry. The fixed name collides across concurrent runs and is blocked by a stale `.tmp` left by a crashed run; the un-retried rename fails on Windows whenever the destination is transiently locked.

2. **`src/lib/atomic-io.js` `writeAtomic()`** uses a randomized tmp name (good) but its `renameSync` likewise had **no Windows retry** — the same latent bug for every caller of the shared helper.

POSIX `rename(2)` is atomic and does not exhibit this; the problem is Windows/NTFS-specific.

## Changes

- `src/lib/atomic-io.js`: add `renameWithRetry()` — bounded exponential backoff (10ms → 250ms cap, max 10 attempts), retries **only** the known-transient codes (`EPERM`/`EACCES`/`EBUSY`/`EEXIST`) and rethrows everything else immediately so real errors are never masked. On non-Windows it does a single `renameSync` — **POSIX behavior is unchanged**. `writeAtomic()` now calls it instead of `renameSync`.
- `src/dream/state-file.js`: `writeDreamState()` now delegates to the shared `writeAtomic()` (randomized tmp name + the new rename-retry), replacing its bespoke fixed-tmp + `renameSync`.

## Testing

- Existing suites pass with no regressions: `test-atomic-io.js`, `test-dream-state-file.js`, `test-tmp-suffix.js`.
- Concurrency hammer on Windows: 500 rapid sequential rewrites + a 50-way concurrent burst against the real dream-state file — **0 failures, file always valid JSON** after every write.

## Notes

Reproduced and fixed on Windows 11 / Node 22. The fix is defensive and no-op on POSIX, so it should be safe across all supported platforms.
